### PR TITLE
added copy to the 'our work' section

### DIFF
--- a/src/components/OurWorkSection.tsx
+++ b/src/components/OurWorkSection.tsx
@@ -14,8 +14,8 @@ const OurWorkSection: React.FC<OurWorkProps> = ({ workRef }) => {
       >
         Recent Work
       </h2>
-      <div className='grid grid-cols-2 grid-rows-2'>
-        <div className='m-5 w-3/4 rounded-lg bg-en-orange p-8 text-white'>
+      <div className='m-auto grid w-5/6 grid-cols-1 grid-rows-2 gap-5 md:grid-cols-2 lg:grid-cols-2'>
+        <div className='w-full rounded-lg bg-en-orange p-8 text-white lg:px-20'>
           <h3 className='pb-4 text-2xl italic'>Cambridge University</h3>
           <p>
             In collaboration with researchers at Cambridge University, our team
@@ -25,7 +25,7 @@ const OurWorkSection: React.FC<OurWorkProps> = ({ workRef }) => {
             extracting insights from over 8 million archival files.
           </p>
         </div>
-        <div className='m-5 w-3/4 rounded-lg bg-en-orange p-8 text-white'>
+        <div className='w-full rounded-lg bg-en-orange p-8 text-white lg:px-20'>
           <h3 className='pb-4 text-2xl italic'>Kindly</h3>
           <p>
             Trafalgar Girls, a charity supporting Ukrainian refugees in the UK,
@@ -36,7 +36,7 @@ const OurWorkSection: React.FC<OurWorkProps> = ({ workRef }) => {
             communicate, provide and receive support as needed.
           </p>
         </div>
-        <div className='m-5 w-3/4 rounded-lg bg-en-orange p-8 text-white'>
+        <div className='rounded-lg  bg-en-orange p-8 text-white lg:px-20'>
           <h3 className='pb-4 text-2xl italic'>Cinesphere</h3>
           <p>
             Discovering independent cinema in London is made easier with


### PR DESCRIPTION
Closes #18 

Added copy to the 'Our Work' section about three projects the team has been involved in:
- Cinesphere
- Kindly
- Cambridge University Scraper

Changed the header from **Our Work** to **Recent Work** and added styling to the section to display cards in a grid pattern.

Small Screen:
![Screenshot 2024-02-05 at 17 02 14](https://github.com/enBloc-org/website/assets/114600712/5262f2e4-bdd3-45b5-b209-c30da9a1dd49)

Desktop:
![Screenshot 2024-02-05 at 17 03 35](https://github.com/enBloc-org/website/assets/114600712/089e5d2e-6382-4db2-869e-920cf3542d49)
